### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/boxofyellow/Ascii3dEngine/security/code-scanning/1](https://github.com/boxofyellow/Ascii3dEngine/security/code-scanning/1)

To fix this problem, add an explicit `permissions` block with the minimum required privileges. Since the workflow only reads the repository contents and does not need to write to anything (like issues or pull requests), the most restrictive (and recommended) option is to set `permissions: contents: read` at the root of the workflow. This ensures that all jobs within the workflow inherit this read-only restriction, unless a specific job defines more granular permissions itself. The change should be implemented directly after the `name: CI` line, but before `on:` (it is allowed at the root level per workflow YAML syntax). No changes or imports elsewhere are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
